### PR TITLE
[API] Add the graduates and careers APIs

### DIFF
--- a/app/api/careers/config/routes.json
+++ b/app/api/careers/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/careers",
+      "handler": "careers.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/careers/count",
+      "handler": "careers.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/careers/:id",
+      "handler": "careers.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/careers",
+      "handler": "careers.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/careers/:id",
+      "handler": "careers.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/careers/:id",
+      "handler": "careers.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/app/api/careers/controllers/careers.js
+++ b/app/api/careers/controllers/careers.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/app/api/careers/models/careers.js
+++ b/app/api/careers/models/careers.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/app/api/careers/models/careers.settings.json
+++ b/app/api/careers/models/careers.settings.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "careers",
+  "info": {
+    "name": "careers"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "mentee": {
+      "type": "string"
+    },
+    "position": {
+      "type": "string"
+    },
+    "mentor_session": {
+      "type": "integer"
+    },
+    "mentor": {
+      "type": "string"
+    },
+    "content": {
+      "type": "richtext"
+    }
+  }
+}

--- a/app/api/careers/models/careers.settings.json
+++ b/app/api/careers/models/careers.settings.json
@@ -25,6 +25,17 @@
     },
     "content": {
       "type": "richtext"
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": [
+        "company",
+        "personalization",
+        "interview"
+      ]
+    },
+    "overview_content": {
+      "type": "text"
     }
   }
 }

--- a/app/api/careers/services/careers.js
+++ b/app/api/careers/services/careers.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/app/api/graduate/config/routes.json
+++ b/app/api/graduate/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/graduates",
+      "handler": "graduate.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/graduates/count",
+      "handler": "graduate.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/graduates/:id",
+      "handler": "graduate.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/graduates",
+      "handler": "graduate.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/graduates/:id",
+      "handler": "graduate.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/graduates/:id",
+      "handler": "graduate.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/app/api/graduate/controllers/graduate.js
+++ b/app/api/graduate/controllers/graduate.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/app/api/graduate/models/graduate.js
+++ b/app/api/graduate/models/graduate.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/app/api/graduate/models/graduate.settings.json
+++ b/app/api/graduate/models/graduate.settings.json
@@ -1,0 +1,28 @@
+{
+  "kind": "collectionType",
+  "collectionName": "graduates",
+  "info": {
+    "name": "graduates",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "session": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "school": {
+      "type": "string"
+    },
+    "department": {
+      "type": "string"
+    }
+  }
+}

--- a/app/api/graduate/services/graduate.js
+++ b/app/api/graduate/services/graduate.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};


### PR DESCRIPTION
# Summary
Add the following APIs
- the graduates API : to get the graduates data
- the careers API : to get the mentees' experience of the career project

# How to create the data for the test?
1. Click the `Graduates` or `Careers` button.
![image](https://user-images.githubusercontent.com/33183531/133932772-3833ca0a-5a8c-4d46-b031-f70028cf5705.png)

2. Click the `Create an entry` button.
![image](https://user-images.githubusercontent.com/33183531/133932801-cb8eb60c-a7d6-4f10-bdbc-18119e5c85d8.png)

3. You can get the careers data from [here](https://www.itseed.tw/careerList) and the graduates' data from [here](https://www.itseed.tw/careerList), then you can add the data and save it by using the GUI.
![image](https://user-images.githubusercontent.com/33183531/133932931-382ba891-20f9-4458-8ada-e099e91bc5eb.png)

4. Notice that you have to publish the data, then you can check the data by calling `http://localhost:1337/graduates` and `http://localhost:1337/careers`
![image](https://user-images.githubusercontent.com/33183531/133933017-ed681c2e-a197-40bf-8c53-cf5ff761e6c3.png)