### PR TITLE
[Auth API] Increase auth api rate limit for the loading test

### DIFF
--- a/app/extensions/users-permissions/config/policies/rateLimit.js
+++ b/app/extensions/users-permissions/config/policies/rateLimit.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const lazyRateLimit = {
+  get RateLimit() {
+    return require('koa2-ratelimit').RateLimit;
+  },
+};
+
+module.exports = async (ctx, next) => {
+  const message = [
+    {
+      messages: [
+        {
+          id: 'Auth.form.error.ratelimit',
+          message: 'Too many attempts, please try again in a minute.',
+        },
+      ],
+    },
+  ];
+
+  return lazyRateLimit.RateLimit.middleware(
+    Object.assign(
+      {},
+      {
+        interval: 1 * 60 * 1000,
+        max: 5,
+        prefixKey: `${ctx.request.path}:${ctx.request.ip}`,
+        message,
+      },
+      strapi.plugins['users-permissions'].config.ratelimit
+    )
+  )(ctx, next);
+};


### PR DESCRIPTION
# Description

Since we want to do a loading test in users' permissions APIs, but those APIs have a rate limit.
So we need to increase the rate limit.

It uses `koa2-ratelimit` in middleware, and we need to add a custom policy or change the one that already exists, you can check the following references to know how the mechanism works.

reference
- https://github.com/strapi/strapi/issues/7016
- https://www.npmjs.com/package/koa2-ratelimit#configuration

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Using `httperf` to call the `/auth/local` API and didn't get `429` error code

Using `httperf`
```
httperf --hog --num-conn 10 --num-call 10 --port=1337 --verbose --server-name 'localhost' \
--add-header="Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjMzNzcxNzI2LCJleHAiOjE2MzYzNjM3MjZ9.njsUNHRn-RDcAMoEX_GRfSuwnF3Hxhm5tVq7fUFr33Y\nAccept: application/json\nContent-Type: application/json\n" \
--uri '/auth/local' --method=POST contents='{"identifier": "nick-test", "password":"password"}' \
httperf --verbose --hog --client=0/1 --server=localhost --server_name=localhost --port=1337 --uri=/auth/local --send-buffer=4096 --recv-buffer=16384 --add-header='Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjMzNzcxNzI2LCJleHAiOjE2MzYzNjM3MjZ9.njsUNHRn-RDcAMoEX_GRfSuwnF3Hxhm5tVq7fUFr33Y\nAccept: application/json\nContent-Type: application/json\n' --method=POST --num-conns=10 --num-calls=10
httperf: warning: open file limit > FD_SETSIZE; limiting max. # of open files to FD_SETSIZE
httperf: maximum number of open descriptors = 1024
Maximum connect burst length: 1

Total: connections 10 requests 100 replies 100 test-duration 4.583 s

Connection rate: 2.2 conn/s (458.3 ms/conn, <=1 concurrent connections)
Connection time [ms]: min 331.1 avg 458.3 max 1218.0 median 348.5 stddev 270.4
Connection time [ms]: connect 0.2
Connection length [replies/conn]: 10.000
```

Logs
```
app_1    | [2021-10-09T11:34:28.525Z] debug POST /auth/local (674 ms) 200
app_1    | [2021-10-09T11:34:28.620Z] debug POST /auth/local (81 ms) 200
app_1    | [2021-10-09T11:34:28.683Z] debug POST /auth/local (50 ms) 200
app_1    | [2021-10-09T11:34:28.733Z] debug POST /auth/local (46 ms) 200
app_1    | [2021-10-09T11:34:28.781Z] debug POST /auth/local (45 ms) 200
app_1    | [2021-10-09T11:34:28.854Z] debug POST /auth/local (66 ms) 200
app_1    | [2021-10-09T11:34:28.915Z] debug POST /auth/local (56 ms) 200
app_1    | [2021-10-09T11:34:28.955Z] debug POST /auth/local (36 ms) 200
app_1    | [2021-10-09T11:34:29.002Z] debug POST /auth/local (42 ms) 200
app_1    | [2021-10-09T11:34:29.043Z] debug POST /auth/local (37 ms) 200
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules